### PR TITLE
Upgrading to blaze and bump version to 0.5.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -16,6 +16,6 @@ Package._transitional_registerBuildPlugin({
 
 Package.on_test(function(api) {
   api.use(['tinytest', 'stylus-latest', 'test-helpers']);
-  api.use('spark');
+  api.use('spacebars');
   api.add_files(['stylus_tests.styl', 'stylus_tests.js'], 'client');
 });

--- a/smart.json
+++ b/smart.json
@@ -3,6 +3,6 @@
   "description": "Expressive, dynamic, robust CSS",
   "author": "Meteor Development Group",
   "homepage": "https://github.com/sbking/meteor-stylus-latest",
-  "version": "0.41.4",
+  "version": "0.5.0",
   "git": "https://github.com/sbking/meteor-stylus-latest.git"
 }


### PR DESCRIPTION
Not really necessary because tests were not passing before anyway. But at least does not give errors.
